### PR TITLE
Fix TypeScript declarations

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -8,5 +8,4 @@ type EndpointMethodsObject = {
 
 export type Api = {
   registerEndpoints: (endpoints: EndpointMethodsObject) => void;
-  rest: RestEndpointMethods;
-};
+} & RestEndpointMethods;

--- a/test/register-endpoints.test.ts
+++ b/test/register-endpoints.test.ts
@@ -27,6 +27,7 @@ describe("Deprecations", () => {
     // make sure .registerEndpoints does not remove other methods on the same scope
     expect(typeof octokit.issues.get).toBe("function");
 
+    // @ts-ignore
     const { data } = await octokit.issues.fooBar();
 
     expect(data).toStrictEqual({ ok: true });


### PR DESCRIPTION
`octokit.rest.*` -> `octokit.*`

That was a remainer of a change that I postponed to the next breaking version