### PR TITLE
Workaround "error TS4023: Exported variable Octokit has or is using name EndpointMethodsObject from external module node_modules/@octokit/plugin-rest-endpoint-methods/dist-types/types but cannot be named."

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,5 @@
-import { EndpointOptions } from "@octokit/types";
-
 import { RestEndpointMethods } from "./generated/rest-endpoint-methods-types";
 
-type EndpointMethodsObject = {
-  [scope: string]: EndpointOptions | EndpointMethodsObject;
-};
-
 export type Api = {
-  registerEndpoints: (endpoints: EndpointMethodsObject) => void;
+  registerEndpoints: (endpoints: any) => void;
 } & RestEndpointMethods;


### PR DESCRIPTION
see https://github.com/octokit/action.js/pull/8