### PR TITLE
🐛 fix(type-writer): fix warning Prettier when running types updater

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -970,13 +970,13 @@
       }
     },
     "@gimenete/type-writer": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@gimenete/type-writer/-/type-writer-0.1.4.tgz",
-      "integrity": "sha512-r6PVCs9xFXbjE73VaSKjEkdd0tstsd3X0obR2M+Nk/IsgfldCKbe3ghoTEHALk34bHb897zmDN5Xei4VNJzv/A==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@gimenete/type-writer/-/type-writer-0.1.5.tgz",
+      "integrity": "sha512-ZeVljCBixwIU4MG3Kqy/3Dc7zfIMCj9kXyCQ6hiutwFqZkTWggrhqNSEc+NfN2ztLjUG+ssdFe7PUcCIXv67aA==",
       "dev": true,
       "requires": {
         "camelcase": "^5.0.0",
-        "prettier": "^1.13.7"
+        "prettier": "^1.19.1"
       }
     },
     "@istanbuljs/load-nyc-config": {
@@ -2045,6 +2045,7 @@
         "bottleneck": "^2.18.1",
         "debug": "^4.0.0",
         "dir-glob": "^3.0.0",
+        "fs-extra": "^8.0.0",
         "globby": "^11.0.0",
         "http-proxy-agent": "^4.0.0",
         "https-proxy-agent": "^5.0.0",
@@ -2062,6 +2063,17 @@
           "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
           "dev": true
         },
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
         "globby": {
           "version": "11.0.0",
           "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.0.tgz",
@@ -2075,6 +2087,21 @@
             "merge2": "^1.3.0",
             "slash": "^3.0.0"
           }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+          "dev": true
         }
       }
     },
@@ -2087,6 +2114,7 @@
         "@semantic-release/error": "^2.2.0",
         "aggregate-error": "^3.0.0",
         "execa": "^4.0.0",
+        "fs-extra": "^8.0.0",
         "lodash": "^4.17.15",
         "nerf-dart": "^1.0.0",
         "normalize-url": "^5.0.0",
@@ -2126,6 +2154,17 @@
             "strip-final-newline": "^2.0.0"
           }
         },
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
         "get-stream": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
@@ -2140,6 +2179,15 @@
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
           "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
           "dev": true
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
         },
         "normalize-url": {
           "version": "5.0.0",
@@ -2211,6 +2259,12 @@
           "version": "0.6.0",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
           "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+          "dev": true
+        },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
           "dev": true
         },
         "which": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "deprecation": "^2.3.1"
   },
   "devDependencies": {
-    "@gimenete/type-writer": "^0.1.4",
+    "@gimenete/type-writer": "^0.1.5",
     "@octokit/core": "^2.1.2",
     "@octokit/graphql": "^4.3.1",
     "@pika/pack": "^0.5.0",


### PR DESCRIPTION
## 📝 Summary
<!--- Provide a general summary of your changes, and if you feel that the commit comments are not descriptive enough, give more detail of your changes -->
To upgrade `@gimenete/type-writer` to the latest version

## ⛱ Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix Prettier `warning` when updating types:
```bash
 { parser: "babylon" } is deprecated; we now treat it as { parser: "babel" }.
```

## 📊 How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. `npm run update-endpoints:types` using `@gimenete/type-writer v0.1.4` to see the warning
2. upgrade to latest @gimenete/type-writer v0.1.5"
3. validate the warning is not happening anymore

## 📸 Screenshots:
### Before
![image](https://user-images.githubusercontent.com/2574275/77124283-b8db7f80-6a42-11ea-898b-d2f7c67a1b8d.png)

### After
![image](https://user-images.githubusercontent.com/2574275/77124263-a9f4cd00-6a42-11ea-8dc4-264c2e319223.png)


## 📚 References:
<!-- Any interesting external link to documentation, article, tweet which can add value to the PR -->
PR fixing the issue on type-writer: https://github.com/gimenete/type-writer/pull/4
Prettier parser deprecation references:
* https://prettier.io/docs/en/options.html#parser
* https://prettier.io/blog/2019/01/20/1.16.0.html#rename-babylon-parser-to-babel-5647-by-wuweiweiwu 
* Other PR: https://github.com/octokit/webhooks.js/pull/115