### PR TITLE
fix: `octokit.git.listRefs()` logs deprecation

### DIFF
--- a/src/generated/endpoints.ts
+++ b/src/generated/endpoints.ts
@@ -1349,7 +1349,8 @@ export default {
         per_page: { type: "integer" },
         repo: { required: true, type: "string" }
       },
-      url: "/repos/:owner/:repo/git/refs/:namespace"
+      url: "/repos/:owner/:repo/git/refs/:namespace",
+      deprecated: "`[@octokit/plugin-rest-endpoint-methods] \"octokit.git.listRefs({ owner, repo, namespace })\" is deprecated. Use \"octokit.git.listMatchingRefs({ owner, repo, ref })\" instead"
     },
     updateRef: {
       method: "PATCH",

--- a/test/deprecations.test.ts
+++ b/test/deprecations.test.ts
@@ -169,4 +169,33 @@ describe("Deprecations", () => {
     });
     expect(warnCalledCount).toEqual(1);
   });
+
+  it("octokit.git.listRefs()", () => {
+    const mock = fetchMock
+      .sandbox()
+      .getOnce("path:/repos/octocat/hello-world/git/refs/heads/", {
+        ok: true
+      });
+    const MyOctokit = Octokit.plugin(restEndpointMethods);
+    let warnCalledCount = 0;
+    const octokit = new MyOctokit({
+      log: {
+        warn: (deprecation: Error) => {
+          warnCalledCount++;
+          expect(deprecation.message).toMatch(
+            `[@octokit/plugin-rest-endpoint-methods] "octokit.git.listRefs({ owner, repo, namespace })" is deprecated. Use "octokit.git.listMatchingRefs({ owner, repo, ref })" instead`
+          );
+        }
+      },
+      request: {
+        fetch: mock
+      }
+    });
+    octokit.git.listRefs({
+      owner: "octocat",
+      repo: "hello-world",
+      namespace: "heads/"
+    });
+    expect(warnCalledCount).toEqual(1);
+  });
 });


### PR DESCRIPTION
thanks @ryanblock for reporting the issue!

test case:
https://runkit.com/gr2m/octokit-git-listrefs-deprecation-check/1.0.0