### PR TITLE
Updated with Skypack links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@
 Browsers
 </th><td width=100%>
 
-Load `@octokit/plugin-rest-endpoint-methods` and [`@octokit/core`](https://github.com/octokit/core.js) (or core-compatible module) directly from [cdn.pika.dev](https://cdn.pika.dev)
+Load `@octokit/plugin-rest-endpoint-methods` and [`@octokit/core`](https://github.com/octokit/core.js) (or core-compatible module) directly from [cdn.skypack.dev](https://cdn.skypack.dev)
 
 ```html
 <script type="module">
-  import { Octokit } from "https://cdn.pika.dev/@octokit/core";
-  import { restEndpointMethods } from "https://cdn.pika.dev/@octokit/plugin-rest-endpoint-methods";
+  import { Octokit } from "https://cdn.skypack.dev/@octokit/core";
+  import { restEndpointMethods } from "https://cdn.skypack.dev/@octokit/plugin-rest-endpoint-methods";
 </script>
 ```
 


### PR DESCRIPTION
Hey @gr2m . Thanks for the opportunity. :) Pika CDN no longer works and has been replaced by Skypack CDN. Please merge the PR. Thansk