### PR TITLE
docs(generated): fix OpenAPI spec link

### DIFF
--- a/src/generated/README.md
+++ b/src/generated/README.md
@@ -1,3 +1,3 @@
 # DO NOT EDIT FILES IN THIS DIRECTORY
 
-All files are generated automatically and will be overwritten next time [GitHub's OpenAPI spec](github.com/github/rest-api-description/) has a new release. If you find a problem, please file an issue.
+All files are generated automatically and will be overwritten next time [GitHub's OpenAPI spec](https://github.com/github/rest-api-description/) has a new release. If you find a problem, please file an issue.


### PR DESCRIPTION
Thanks for maintaining the octokit modules, they are quite impressive!

While I was looking around, I noticed that the link to "GitHub's OpenAPI spec" in [`src/generated/README.md`](https://github.com/octokit/plugin-rest-endpoint-methods.js/blob/15f8b00/src/generated/README.md) is dead.  The cause is that, without a protocol, this link is interpreted as a relative URL.  If the file is viewed at https://github.com/octokit/plugin-rest-endpoint-methods.js/blob/master/src/generated/README.md, the link resolves to https://github.com/octokit/plugin-rest-endpoint-methods.js/blob/master/src/generated/github.com/github/rest-api-description which does not exist.  This PR adds `https://` so the link resolves to https://github.com/github/rest-api-description which I assume is the original intention.

Thanks,
Kevin