### PR TITLE
feat: `legacyRestEndpointMethods` export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,8 +9,16 @@ import { endpointsToMethods } from "./endpoints-to-methods";
 export function restEndpointMethods(octokit: Octokit): Api {
   const api = endpointsToMethods(octokit, ENDPOINTS);
   return {
-    ...api,
     rest: api,
   };
 }
 restEndpointMethods.VERSION = VERSION;
+
+export function legacyRestEndpointMethods(octokit: Octokit): Api["rest"] & Api {
+  const api = endpointsToMethods(octokit, ENDPOINTS);
+  return {
+    ...api,
+    rest: api,
+  };
+}
+legacyRestEndpointMethods.VERSION = VERSION;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,9 +2,7 @@ import { Route, RequestParameters } from "@octokit/types";
 
 import { RestEndpointMethods } from "./generated/method-types";
 
-export type Api = RestEndpointMethods & {
-  rest: RestEndpointMethods;
-};
+export type Api = { rest: RestEndpointMethods };
 
 export type EndpointDecorations = {
   mapToData?: string;


### PR DESCRIPTION
BREAKING CHANGE: No methods are set on `octokit.*` any more, only on `octokit.rest.*`. You can use `Octokit.plugin(legacyRestEndpointMethods)` to recover the previous behavior for the forseeable time, but eventually it will be deprecated and removed
