### PR TITLE
fix: update required parameters

### DIFF
--- a/docs/repos/uploadReleaseAsset.md
+++ b/docs/repos/uploadReleaseAsset.md
@@ -59,7 +59,7 @@ octokit.rest.repos.uploadReleaseAsset({
 release_id parameter
 
 </td></tr>
-<tr><td>name</td><td>no</td><td>
+<tr><td>name</td><td>yes</td><td>
 
 </td></tr>
 <tr><td>label</td><td>no</td><td>


### PR DESCRIPTION
Hey everyone, let me describe the issue:

When I try to upload a release asset via `@octokit/rest` excluding a name parameter only returns `400`. Therefore I think the name parameter is required.