### PR TITLE
build(npm): replace 'pika' command with 'pika-pack'

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0-development",
   "description": "Octokit plugin adding one method for all of api.github.com REST API endpoints",
   "scripts": {
-    "build": "pika build",
+    "build": "pika-pack build",
     "lint": "prettier --check '{src,test}/**/*' '!src/generated/**' README.md package.json",
     "lint:fix": "prettier --write '{src,test}/**/*' '!src/generated/**' README.md package.json",
     "pretest": "npm run -s lint",


### PR DESCRIPTION
# Description
Replace build script in package.json from `pika build` to `pika-pack build.`
You can read more about this in [Pika Release Notes](https://github.com/FredKSchott/pika-pack/releases/tag/v0.5.0)

# Context
Avoid Release issues like the one reported [here](https://github.com/octokit/plugin-retry.js/issues/321)