### PR TITLE
fix: pin to a specific version of `@octokit/types`

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: 16
           cache: npm
       - run: git checkout routes-update || true
-      - run: npm install @octokit/types@latest
+      - run: npm install --save-exact @octokit/types@latest
         if: >-
           github.event_name == 'repository_dispatch' && github.event.action ==
           'octokit/types.ts release'

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^6.40.0",
+        "@octokit/types": "6.40.0",
         "deprecation": "^2.3.1"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "author": "Gregor Martynus (https://twitter.com/gr2m)",
   "license": "MIT",
   "dependencies": {
-    "@octokit/types": "^6.40.0",
+    "@octokit/types": "6.40.0",
     "deprecation": "^2.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
When the `@octokit/types` package is updated, we run the "update" workflow in GitHub Actions to update this code and push a PR.

At the moment, we're seeing fairly regular bugs affecting this plugin (e.g. https://github.com/octokit/types.ts/issues/426) where it is used with an incompatible version of `@octokit/types`, so new types that have been introduced are not there.

The reality is that this plugin is only guaranteed to work with a specific version of the types. If you end up updating this plugin but not the types (which is what npm will do naturally), they can be out of sync.

This doesn't only apply to what might seem like major version "breaking changes" to the types. If the types introduce a new endpoint, and you haven't upgraded, then this package will be broken because it will refer to that endpoint without the types being present.

This tweaks the "update" task so it sets in the `package.json` an *exact* version of `@octokit/types` which should be used. This ensures that it is used with a compatible version that does not generate errors.