### PR TITLE
Revert "fix: pin to a specific version of `@octokit/types`"

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: 16
           cache: npm
       - run: git checkout routes-update || true
-      - run: npm install --save-exact @octokit/types@latest
+      - run: npm install @octokit/types@latest
         if: >-
           github.event_name == 'repository_dispatch' && github.event.action ==
           'octokit/types.ts release'

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "6.40.0",
+        "@octokit/types": "^6.40.0",
         "deprecation": "^2.3.1"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "author": "Gregor Martynus (https://twitter.com/gr2m)",
   "license": "MIT",
   "dependencies": {
-    "@octokit/types": "6.40.0",
+    "@octokit/types": "^6.40.0",
     "deprecation": "^2.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Reverts octokit/plugin-rest-endpoint-methods.js#520

See discussion in the previous PR - this will lead to multiple versions existing in parallel, meaning even more confusing bugs. 