### PR TITLE
docs: replace references to Skypack CDN with esm.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@
 Browsers
 </th><td width=100%>
 
-Load `@octokit/plugin-rest-endpoint-methods` and [`@octokit/core`](https://github.com/octokit/core.js) (or core-compatible module) directly from [cdn.skypack.dev](https://cdn.skypack.dev)
+Load `@octokit/plugin-rest-endpoint-methods` and [`@octokit/core`](https://github.com/octokit/core.js) (or core-compatible module) directly from [esm.sh](https://esm.sh)
 
 ```html
 <script type="module">
-  import { Octokit } from "https://cdn.skypack.dev/@octokit/core";
-  import { restEndpointMethods } from "https://cdn.skypack.dev/@octokit/plugin-rest-endpoint-methods";
+  import { Octokit } from "https://esm.sh/@octokit/core";
+  import { restEndpointMethods } from "https://esm.sh/@octokit/plugin-rest-endpoint-methods";
 </script>
 ```
 


### PR DESCRIPTION
The Skypack CDN is no longer maintained, so we should remove references to it.