### PR TITLE
refactor: use `node:` specifier imports and full relative paths in imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,9 @@
         "functions": 100,
         "lines": 100
       }
+    },
+    "moduleNameMapper": {
+      "^(.+)\\.jsx?$": "$1"
     }
   },
   "release": {

--- a/scripts/update-endpoints/code.mjs
+++ b/scripts/update-endpoints/code.mjs
@@ -1,6 +1,6 @@
-import { readFileSync, writeFileSync } from "fs";
-import { join } from "path";
-import { fileURLToPath } from "url";
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { format } from "prettier";
 import sortKeys from "sort-keys";

--- a/scripts/update-endpoints/code.mjs
+++ b/scripts/update-endpoints/code.mjs
@@ -123,7 +123,7 @@ async function generateRoutes() {
   writeFileSync(
     ROUTES_PATH,
     await format(
-      `import type { EndpointsDefaultsAndDecorations } from "../types";
+      `import type { EndpointsDefaultsAndDecorations } from "../types.js";
   const Endpoints: EndpointsDefaultsAndDecorations = ${JSON.stringify(
     sortKeys(newRoutes, { deep: true }),
   )}

--- a/scripts/update-endpoints/docs.mjs
+++ b/scripts/update-endpoints/docs.mjs
@@ -1,7 +1,7 @@
 import { format } from "prettier";
 
 import { isDeprecated } from "./util.mjs";
-import { readFileSync, mkdirSync, writeFileSync } from "fs";
+import { readFileSync, mkdirSync, writeFileSync } from "node:fs";
 
 const ENDPOINTS = JSON.parse(
   readFileSync(

--- a/scripts/update-endpoints/fetch-json.mjs
+++ b/scripts/update-endpoints/fetch-json.mjs
@@ -1,6 +1,6 @@
-import { writeFileSync } from "fs";
-import { resolve } from "path";
-import { fileURLToPath } from "url";
+import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import graphql from "github-openapi-graphql-query";
 import { format } from "prettier";

--- a/scripts/update-endpoints/types.mjs
+++ b/scripts/update-endpoints/types.mjs
@@ -1,5 +1,5 @@
-import { writeFileSync, readFileSync } from "fs";
-import { join as pathJoin } from "path";
+import { writeFileSync, readFileSync } from "node:fs";
+import { join as pathJoin } from "node:path";
 
 import camelCase from "lodash.camelcase";
 import { format } from "prettier";

--- a/src/endpoints-to-methods.ts
+++ b/src/endpoints-to-methods.ts
@@ -1,8 +1,8 @@
 import type { Octokit } from "@octokit/core";
 import type { EndpointOptions, RequestParameters, Route } from "@octokit/types";
-import ENDPOINTS from "./generated/endpoints";
-import type { RestEndpointMethods } from "./generated/method-types";
-import type { EndpointDecorations } from "./types";
+import ENDPOINTS from "./generated/endpoints.js";
+import type { RestEndpointMethods } from "./generated/method-types.js";
+import type { EndpointDecorations } from "./types.js";
 
 // The following code was refactored in: https://github.com/octokit/plugin-rest-endpoint-methods.js/pull/622
 // to optimise the runtime performance of Octokit initialization.

--- a/src/generated/endpoints.ts
+++ b/src/generated/endpoints.ts
@@ -1,4 +1,4 @@
-import type { EndpointsDefaultsAndDecorations } from "../types";
+import type { EndpointsDefaultsAndDecorations } from "../types.js";
 const Endpoints: EndpointsDefaultsAndDecorations = {
   actions: {
     addCustomLabelsToSelfHostedRunnerForOrg: [

--- a/src/generated/method-types.ts
+++ b/src/generated/method-types.ts
@@ -1,5 +1,5 @@
 import type { EndpointInterface, RequestInterface } from "@octokit/types";
-import type { RestEndpointMethodTypes } from "./parameters-and-response-types";
+import type { RestEndpointMethodTypes } from "./parameters-and-response-types.js";
 
 export type RestEndpointMethods = {
   actions: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 import type { Octokit } from "@octokit/core";
 
-export type { RestEndpointMethodTypes } from "./generated/parameters-and-response-types";
-import { VERSION } from "./version";
-import type { Api } from "./types";
-import { endpointsToMethods } from "./endpoints-to-methods";
+export type { RestEndpointMethodTypes } from "./generated/parameters-and-response-types.js";
+import { VERSION } from "./version.js";
+import type { Api } from "./types.js";
+import { endpointsToMethods } from "./endpoints-to-methods.js";
 
 export function restEndpointMethods(octokit: Octokit): Api {
   const api = endpointsToMethods(octokit);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import type { Route, RequestParameters } from "@octokit/types";
 
-import type { RestEndpointMethods } from "./generated/method-types";
+import type { RestEndpointMethods } from "./generated/method-types.js";
 
 export type Api = { rest: RestEndpointMethods };
 

--- a/test/issues.test.ts
+++ b/test/issues.test.ts
@@ -1,7 +1,7 @@
 import fetchMock from "fetch-mock";
 import { Octokit } from "@octokit/core";
 
-import { restEndpointMethods } from "../src";
+import { restEndpointMethods } from "../src/index.ts";
 
 describe("https://github.com/octokit/plugin-rest-endpoint-methods.js/issues/83", () => {
   it("git.gists.update({ gist_id, files })", async () => {

--- a/test/rest-endpoint-methods.test.ts
+++ b/test/rest-endpoint-methods.test.ts
@@ -2,8 +2,11 @@ import { Octokit } from "@octokit/core";
 import fetchMock from "fetch-mock";
 
 import sinon from "sinon";
-import { legacyRestEndpointMethods, restEndpointMethods } from "../src";
-import { Api } from "../src/types";
+import {
+  legacyRestEndpointMethods,
+  restEndpointMethods,
+} from "../src/index.ts";
+import { Api } from "../src/types.ts";
 
 describe("REST API endpoint methods", () => {
   it("README example", async () => {

--- a/test/smoke.test.ts
+++ b/test/smoke.test.ts
@@ -1,4 +1,4 @@
-import { restEndpointMethods } from "../src";
+import { restEndpointMethods } from "../src/index.ts";
 
 describe("Smoke test", () => {
   it("is a function", () => {

--- a/test/tsconfig.test.json
+++ b/test/tsconfig.test.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "emitDeclarationOnly": false,
     "noEmit": true,
-    "verbatimModuleSyntax": false
+    "verbatimModuleSyntax": false,
+    "allowImportingTsExtensions": true
   },
   "include": ["src/**/*"]
 }

--- a/test/typescript.test.ts
+++ b/test/typescript.test.ts
@@ -1,5 +1,5 @@
 import { Octokit } from "@octokit/core";
-import { RestEndpointMethodTypes, restEndpointMethods } from "../src";
+import { RestEndpointMethodTypes, restEndpointMethods } from "../src/index.ts";
 
 describe("Smoke test", () => {
   it("Get parameters type for octokit.rest.issues.updateLabel()", async () => {


### PR DESCRIPTION
This PR replaces NodeJS internal module imports with `node:` specifier imports.