### PR TITLE
feat: `.actions.{getCustomOidcSubClaimForRepo,setCustomOidcSubClaimForRepo}`, `.oidc.{getOidcCustomSubTemplateForOrg,updateOidcCustomSubTemplateForOrg}`

### DIFF
--- a/docs/actions/getCustomOidcSubClaimForRepo.md
+++ b/docs/actions/getCustomOidcSubClaimForRepo.md
@@ -1,0 +1,46 @@
+---
+name: Get the customization template for an OIDC subject claim for a repository
+example: octokit.rest.actions.getCustomOidcSubClaimForRepo({ owner, repo })
+route: GET /repos/{owner}/{repo}/actions/oidc/customization/sub
+scope: actions
+type: API method
+---
+
+# Get the customization template for an OIDC subject claim for a repository
+
+Gets the customization template for an OpenID Connect (OIDC) subject claim.
+You must authenticate using an access token with the `repo` scope to use this
+endpoint. GitHub Apps must have the `organization_administration:read` permission to use this endpoint.
+
+```js
+octokit.rest.actions.getCustomOidcSubClaimForRepo({
+  owner,
+  repo,
+});
+```
+
+## Parameters
+
+<table>
+  <thead>
+    <tr>
+      <th>name</th>
+      <th>required</th>
+      <th>description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td>owner</td><td>yes</td><td>
+
+The account owner of the repository. The name is not case sensitive.
+
+</td></tr>
+<tr><td>repo</td><td>yes</td><td>
+
+The name of the repository without the `.git` extension. The name is not case sensitive.
+
+</td></tr>
+  </tbody>
+</table>
+
+See also: [GitHub Developer Guide documentation](https://docs.github.com/rest/actions/oidc#get-the-customization-template-for-an-oidc-subject-claim-for-a-repository).

--- a/docs/actions/setCustomOidcSubClaimForRepo.md
+++ b/docs/actions/setCustomOidcSubClaimForRepo.md
@@ -1,0 +1,57 @@
+---
+name: Set the customization template for an OIDC subject claim for a repository
+example: octokit.rest.actions.setCustomOidcSubClaimForRepo({ owner, repo, use_default })
+route: PUT /repos/{owner}/{repo}/actions/oidc/customization/sub
+scope: actions
+type: API method
+---
+
+# Set the customization template for an OIDC subject claim for a repository
+
+Sets the customization template and `opt-in` or `opt-out` flag for an OpenID Connect (OIDC) subject claim for a repository.
+You must authenticate using an access token with the `repo` scope to use this
+endpoint. GitHub Apps must have the `actions:write` permission to use this endpoint.
+
+```js
+octokit.rest.actions.setCustomOidcSubClaimForRepo({
+  owner,
+  repo,
+  use_default,
+});
+```
+
+## Parameters
+
+<table>
+  <thead>
+    <tr>
+      <th>name</th>
+      <th>required</th>
+      <th>description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td>owner</td><td>yes</td><td>
+
+The account owner of the repository. The name is not case sensitive.
+
+</td></tr>
+<tr><td>repo</td><td>yes</td><td>
+
+The name of the repository without the `.git` extension. The name is not case sensitive.
+
+</td></tr>
+<tr><td>use_default</td><td>yes</td><td>
+
+Whether to use the default template or not. If `true`, the `include_claim_keys` field is ignored.
+
+</td></tr>
+<tr><td>include_claim_keys</td><td>no</td><td>
+
+Array of unique strings. Each claim key can only contain alphanumeric characters and underscores.
+
+</td></tr>
+  </tbody>
+</table>
+
+See also: [GitHub Developer Guide documentation](https://docs.github.com/rest/actions/oidc#set-the-customization-template-for-an-oidc-subject-claim-for-a-repository).

--- a/docs/oidc/getOidcCustomSubTemplateForOrg.md
+++ b/docs/oidc/getOidcCustomSubTemplateForOrg.md
@@ -1,0 +1,40 @@
+---
+name: Get the customization template for an OIDC subject claim for an organization
+example: octokit.rest.oidc.getOidcCustomSubTemplateForOrg({ org })
+route: GET /orgs/{org}/actions/oidc/customization/sub
+scope: oidc
+type: API method
+---
+
+# Get the customization template for an OIDC subject claim for an organization
+
+Gets the customization template for an OpenID Connect (OIDC) subject claim.
+You must authenticate using an access token with the `read:org` scope to use this endpoint.
+GitHub Apps must have the `organization_administration:write` permission to use this endpoint.
+
+```js
+octokit.rest.oidc.getOidcCustomSubTemplateForOrg({
+  org,
+});
+```
+
+## Parameters
+
+<table>
+  <thead>
+    <tr>
+      <th>name</th>
+      <th>required</th>
+      <th>description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td>org</td><td>yes</td><td>
+
+The organization name. The name is not case sensitive.
+
+</td></tr>
+  </tbody>
+</table>
+
+See also: [GitHub Developer Guide documentation](https://docs.github.com/rest/actions/oidc#get-the-customization-template-for-an-oidc-subject-claim-for-an-organization).

--- a/docs/oidc/updateOidcCustomSubTemplateForOrg.md
+++ b/docs/oidc/updateOidcCustomSubTemplateForOrg.md
@@ -1,0 +1,46 @@
+---
+name: Set the customization template for an OIDC subject claim for an organization
+example: octokit.rest.oidc.updateOidcCustomSubTemplateForOrg({ org, include_claim_keys })
+route: PUT /orgs/{org}/actions/oidc/customization/sub
+scope: oidc
+type: API method
+---
+
+# Set the customization template for an OIDC subject claim for an organization
+
+Creates or updates the customization template for an OpenID Connect (OIDC) subject claim.
+You must authenticate using an access token with the `write:org` scope to use this endpoint.
+GitHub Apps must have the `admin:org` permission to use this endpoint.
+
+```js
+octokit.rest.oidc.updateOidcCustomSubTemplateForOrg({
+  org,
+  include_claim_keys,
+});
+```
+
+## Parameters
+
+<table>
+  <thead>
+    <tr>
+      <th>name</th>
+      <th>required</th>
+      <th>description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td>org</td><td>yes</td><td>
+
+The organization name. The name is not case sensitive.
+
+</td></tr>
+<tr><td>include_claim_keys</td><td>yes</td><td>
+
+Array of unique strings. Each claim key can only contain alphanumeric characters and underscores.
+
+</td></tr>
+  </tbody>
+</table>
+
+See also: [GitHub Developer Guide documentation](https://docs.github.com/rest/actions/oidc#set-the-customization-template-for-an-oidc-subject-claim-for-an-organization).

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@types/sinon": "^17.0.0",
         "esbuild": "^0.20.0",
         "fetch-mock": "npm:@gr2m/fetch-mock@^9.11.0-pull-request-644.1",
-        "github-openapi-graphql-query": "^4.0.0",
+        "github-openapi-graphql-query": "^4.3.1",
         "glob": "^10.2.6",
         "jest": "^29.0.0",
         "lodash.camelcase": "^4.3.0",
@@ -2830,9 +2830,10 @@
       }
     },
     "node_modules/github-openapi-graphql-query": {
-      "version": "4.1.0",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/github-openapi-graphql-query/-/github-openapi-graphql-query-4.3.1.tgz",
+      "integrity": "sha512-q+P5IQ8mwZeaL5giIxwk4DquA8fQLuAY3mtu6KI1funbHJpl9eshy5BvTZH1FvVDTi5FJMnzHQUR1L+0dPpHsw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@graphql-tools/schema": "^10.0.0",
         "got": "^11.8.5",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@types/sinon": "^17.0.0",
     "esbuild": "^0.20.0",
     "fetch-mock": "npm:@gr2m/fetch-mock@^9.11.0-pull-request-644.1",
-    "github-openapi-graphql-query": "^4.0.0",
+    "github-openapi-graphql-query": "^4.3.1",
     "glob": "^10.2.6",
     "jest": "^29.0.0",
     "lodash.camelcase": "^4.3.0",

--- a/src/generated/endpoints.ts
+++ b/src/generated/endpoints.ts
@@ -123,6 +123,9 @@ const Endpoints: EndpointsDefaultsAndDecorations = {
       "GET /repos/{owner}/{repo}/actions/permissions/selected-actions",
     ],
     getArtifact: ["GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}"],
+    getCustomOidcSubClaimForRepo: [
+      "GET /repos/{owner}/{repo}/actions/oidc/customization/sub",
+    ],
     getEnvironmentPublicKey: [
       "GET /repositories/{repository_id}/environments/{environment_name}/secrets/public-key",
     ],
@@ -274,6 +277,9 @@ const Endpoints: EndpointsDefaultsAndDecorations = {
     ],
     setCustomLabelsForSelfHostedRunnerForRepo: [
       "PUT /repos/{owner}/{repo}/actions/runners/{runner_id}/labels",
+    ],
+    setCustomOidcSubClaimForRepo: [
+      "PUT /repos/{owner}/{repo}/actions/oidc/customization/sub",
     ],
     setGithubActionsDefaultWorkflowPermissionsOrganization: [
       "PUT /orgs/{org}/actions/permissions/workflow",
@@ -942,6 +948,14 @@ const Endpoints: EndpointsDefaultsAndDecorations = {
         deprecated:
           "octokit.rest.migrations.updateImport() is deprecated, see https://docs.github.com/rest/migrations/source-imports#update-an-import",
       },
+    ],
+  },
+  oidc: {
+    getOidcCustomSubTemplateForOrg: [
+      "GET /orgs/{org}/actions/oidc/customization/sub",
+    ],
+    updateOidcCustomSubTemplateForOrg: [
+      "PUT /orgs/{org}/actions/oidc/customization/sub",
     ],
   },
   orgs: {

--- a/src/generated/method-types.ts
+++ b/src/generated/method-types.ts
@@ -848,6 +848,20 @@ export type RestEndpointMethods = {
       endpoint: EndpointInterface<{ url: string }>;
     };
     /**
+     * Gets the customization template for an OpenID Connect (OIDC) subject claim.
+     * You must authenticate using an access token with the `repo` scope to use this
+     * endpoint. GitHub Apps must have the `organization_administration:read` permission to use this endpoint.
+     */
+    getCustomOidcSubClaimForRepo: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["getCustomOidcSubClaimForRepo"]["parameters"],
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["getCustomOidcSubClaimForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
      * Get the public key for an environment, which you need to encrypt environment
      * secrets. You need to encrypt a secret before you can create or update secrets.
      *
@@ -1837,6 +1851,20 @@ export type RestEndpointMethods = {
         params?: RestEndpointMethodTypes["actions"]["setCustomLabelsForSelfHostedRunnerForRepo"]["parameters"],
       ): Promise<
         RestEndpointMethodTypes["actions"]["setCustomLabelsForSelfHostedRunnerForRepo"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Sets the customization template and `opt-in` or `opt-out` flag for an OpenID Connect (OIDC) subject claim for a repository.
+     * You must authenticate using an access token with the `repo` scope to use this
+     * endpoint. GitHub Apps must have the `actions:write` permission to use this endpoint.
+     */
+    setCustomOidcSubClaimForRepo: {
+      (
+        params?: RestEndpointMethodTypes["actions"]["setCustomOidcSubClaimForRepo"]["parameters"],
+      ): Promise<
+        RestEndpointMethodTypes["actions"]["setCustomOidcSubClaimForRepo"]["response"]
       >;
       defaults: RequestInterface["defaults"];
       endpoint: EndpointInterface<{ url: string }>;
@@ -6376,6 +6404,36 @@ export type RestEndpointMethods = {
         params?: RestEndpointMethodTypes["migrations"]["updateImport"]["parameters"],
       ): Promise<
         RestEndpointMethodTypes["migrations"]["updateImport"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+  };
+  oidc: {
+    /**
+     * Gets the customization template for an OpenID Connect (OIDC) subject claim.
+     * You must authenticate using an access token with the `read:org` scope to use this endpoint.
+     * GitHub Apps must have the `organization_administration:write` permission to use this endpoint.
+     */
+    getOidcCustomSubTemplateForOrg: {
+      (
+        params?: RestEndpointMethodTypes["oidc"]["getOidcCustomSubTemplateForOrg"]["parameters"],
+      ): Promise<
+        RestEndpointMethodTypes["oidc"]["getOidcCustomSubTemplateForOrg"]["response"]
+      >;
+      defaults: RequestInterface["defaults"];
+      endpoint: EndpointInterface<{ url: string }>;
+    };
+    /**
+     * Creates or updates the customization template for an OpenID Connect (OIDC) subject claim.
+     * You must authenticate using an access token with the `write:org` scope to use this endpoint.
+     * GitHub Apps must have the `admin:org` permission to use this endpoint.
+     */
+    updateOidcCustomSubTemplateForOrg: {
+      (
+        params?: RestEndpointMethodTypes["oidc"]["updateOidcCustomSubTemplateForOrg"]["parameters"],
+      ): Promise<
+        RestEndpointMethodTypes["oidc"]["updateOidcCustomSubTemplateForOrg"]["response"]
       >;
       defaults: RequestInterface["defaults"];
       endpoint: EndpointInterface<{ url: string }>;

--- a/src/generated/parameters-and-response-types.ts
+++ b/src/generated/parameters-and-response-types.ts
@@ -242,6 +242,11 @@ export type RestEndpointMethodTypes = {
         Endpoints["GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}"]["parameters"];
       response: Endpoints["GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}"]["response"];
     };
+    getCustomOidcSubClaimForRepo: {
+      parameters: RequestParameters &
+        Endpoints["GET /repos/{owner}/{repo}/actions/oidc/customization/sub"]["parameters"];
+      response: Endpoints["GET /repos/{owner}/{repo}/actions/oidc/customization/sub"]["response"];
+    };
     getEnvironmentPublicKey: {
       parameters: RequestParameters &
         Endpoints["GET /repositories/{repository_id}/environments/{environment_name}/secrets/public-key"]["parameters"];
@@ -561,6 +566,11 @@ export type RestEndpointMethodTypes = {
       parameters: RequestParameters &
         Endpoints["PUT /repos/{owner}/{repo}/actions/runners/{runner_id}/labels"]["parameters"];
       response: Endpoints["PUT /repos/{owner}/{repo}/actions/runners/{runner_id}/labels"]["response"];
+    };
+    setCustomOidcSubClaimForRepo: {
+      parameters: RequestParameters &
+        Endpoints["PUT /repos/{owner}/{repo}/actions/oidc/customization/sub"]["parameters"];
+      response: Endpoints["PUT /repos/{owner}/{repo}/actions/oidc/customization/sub"]["response"];
     };
     setGithubActionsDefaultWorkflowPermissionsOrganization: {
       parameters: RequestParameters &
@@ -2142,6 +2152,18 @@ export type RestEndpointMethodTypes = {
       parameters: RequestParameters &
         Endpoints["PATCH /repos/{owner}/{repo}/import"]["parameters"];
       response: Endpoints["PATCH /repos/{owner}/{repo}/import"]["response"];
+    };
+  };
+  oidc: {
+    getOidcCustomSubTemplateForOrg: {
+      parameters: RequestParameters &
+        Endpoints["GET /orgs/{org}/actions/oidc/customization/sub"]["parameters"];
+      response: Endpoints["GET /orgs/{org}/actions/oidc/customization/sub"]["response"];
+    };
+    updateOidcCustomSubTemplateForOrg: {
+      parameters: RequestParameters &
+        Endpoints["PUT /orgs/{org}/actions/oidc/customization/sub"]["parameters"];
+      response: Endpoints["PUT /orgs/{org}/actions/oidc/customization/sub"]["response"];
     };
   };
   orgs: {


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->

Ship https://github.com/gr2m/github-openapi-graphql-query/pull/131, which generates now the missing oidc customization endpoints like https://docs.github.com/en/rest/actions/oidc?apiVersion=2022-11-28#set-the-customization-template-for-an-oidc-subject-claim-for-an-organization

---

### Before the change?

<!-- Please describe the current behavior that you are modifying. -->

- Missing oidc customization endpoints

### After the change?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added oidc customization endpoints

### Pull request checklist

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

---
