### PR TITLE
fix: add `main` entry point

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -59,7 +59,7 @@ async function main() {
           ".": {
             import: "./dist-src/index.js",
             types: "./dist-types/index.d.ts",
-          }
+          },
         },
         sideEffects: false,
       },

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -53,8 +53,14 @@ async function main() {
       {
         ...pkg,
         files: ["dist-*/**"],
-        exports: "./dist-src/index.js",
+        main: "./dist-src/index.js",
         types: "./dist-types/index.d.ts",
+        exports: {
+          ".": {
+            import: "./dist-src/index.js",
+            types: "./dist-types/index.d.ts",
+          }
+        },
         sideEffects: false,
       },
       null,


### PR DESCRIPTION
Some tools don't play well with only having the `exports` field present.

See octokit/core.js#662
