### PR TITLE
Add missing backtick in parameter of listAlertsForRepo.md

### DIFF
--- a/docs/codeScanning/listAlertsForRepo.md
+++ b/docs/codeScanning/listAlertsForRepo.md
@@ -84,7 +84,7 @@ The property by which to sort the results. `number` is deprecated - we recommend
 </td></tr>
 <tr><td>state</td><td>no</td><td>
 
-Set to `open`, `closed, `fixed`, or `dismissed` to list code scanning alerts in a specific state.
+Set to `open`, `closed`, `fixed`, or `dismissed` to list code scanning alerts in a specific state.
 
 </td></tr>
   </tbody>


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->

~Resolves #ISSUE_NUMBER~

---

### Before the change?

<!-- Please describe the current behavior that you are modifying. -->

Due to a missing backtick character, the markdown formatting inverted. For example: the states may be `open`, `closed, or `fixed`.

### After the change?

<!-- Please describe the behavior or changes that are being added by this PR. -->

With the missing backtick included, the formatting was fixed and as it was intended. For example, the states may be `open`, `closed`, or `fixed`.

### Pull request checklist

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

---
