### PR TITLE
Changed default export to point to dist-src instead of dist-types

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -59,7 +59,7 @@ async function main() {
             import: "./dist-src/index.js",
             types: "./dist-types/index.d.ts",
             // Tooling currently are having issues with the "exports" field when there is no "default", ex: TypeScript, eslint
-            default: "./dist-types/index.js",
+            default: "./dist-src/index.js",
           },
         },
         sideEffects: false,


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->

Resolves octokit/core.js#665
Resolves octokit/core.js#667

Resolves https://github.com/octokit/plugin-rest-endpoint-methods.js/pull/733#issuecomment-2075202239

I have tested this with `jest` - doesn't work before, works after :). (skaut/poptavky#1406)

---

### Before the change?

<!-- Please describe the current behavior that you are modifying. -->

- Some consumers of this package could not resolve it properly (ex: `jest`, `ts-node`, `tsx`)

### After the change?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Clients should be able to import the module without any errors with the fallback

### Pull request checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

---
