### PR TITLE
fix(types): export `Api`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,10 @@ import { VERSION } from "./version.js";
 import type { Api } from "./types.js";
 import { endpointsToMethods } from "./endpoints-to-methods.js";
 
+// Export the type for downstream users in order to fix a TypeScript error
+// The inferred type of 'Octokit' cannot be named without a reference to '../node_modules/@octokit/plugin-rest-endpoint-methods/dist-types/types.js'. This is likely not portable. A type annotation is necessary.
+export type { Api };
+
 export function restEndpointMethods(octokit: Octokit): Api {
   const api = endpointsToMethods(octokit);
   return {


### PR DESCRIPTION
This resolves issues in consumers of this package getting errors from TypeScript

```
The inferred type of 'Octokit' cannot be named without a reference to '../node_modules/@octokit/plugin-rest-endpoint-methods/dist-types/types.js'. This is likely not portable. A type annotation is necessary.
```

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->

Resolves #ISSUE_NUMBER

---

### Before the change?

<!-- Please describe the current behavior that you are modifying. -->

-

### After the change?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-

### Pull request checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [ ] No

---
